### PR TITLE
Fix 'odoo_project_migration' dependency

### DIFF
--- a/odoo_project_migration/__manifest__.py
+++ b/odoo_project_migration/__manifest__.py
@@ -17,6 +17,7 @@
     "installable": True,
     "depends": [
         "odoo_project",
+        "odoo_repository_migration",
     ],
     "license": "AGPL-3",
 }


### PR DESCRIPTION
Module cannot be installed because Odoo fails to setup `_compute_state()` dependencies: field `module_migration_id` is a `Many2one` against `odoo.module.branch.migration`, which is not initialized if module `odoo_repository_migration` is not already installed (so we add it as dependency)