### PR TITLE
New data model `odoo.project.module`

### DIFF
--- a/odoo_project/__manifest__.py
+++ b/odoo_project/__manifest__.py
@@ -9,8 +9,10 @@
     "website": "https://github.com/OCA/TODO",
     "data": [
         "security/ir.model.access.csv",
+        "views/menu.xml",
         "views/odoo_module_branch.xml",
         "views/odoo_project.xml",
+        "views/odoo_project_module.xml",
         "wizards/odoo_project_import_modules.xml",
     ],
     "installable": True,

--- a/odoo_project/models/__init__.py
+++ b/odoo_project/models/__init__.py
@@ -1,2 +1,3 @@
 from . import odoo_project
+from . import odoo_project_module
 from . import odoo_module_branch

--- a/odoo_project/models/odoo_module_branch.py
+++ b/odoo_project/models/odoo_module_branch.py
@@ -1,15 +1,27 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class OdooModuleBranch(models.Model):
     _inherit = "odoo.module.branch"
 
+    odoo_project_module_ids = fields.One2many(
+        comodel_name="odoo.project.module",
+        inverse_name="module_branch_id",
+        string="Deployed Modules",
+    )
     odoo_project_ids = fields.Many2many(
         comodel_name="odoo.project",
         relation="odoo_project_module_branch_rel",
         column1="module_branch_id", column2="odoo_project_id",
         string="Projects",
+        compute="_compute_module_ids",
+        store=True,
     )
+
+    @api.depends("odoo_project_module_ids.odoo_project_id")
+    def _compute_module_ids(self):
+        for rec in self:
+            rec.odoo_project_ids = rec.odoo_project_module_ids.odoo_project_id.ids

--- a/odoo_project/models/odoo_project.py
+++ b/odoo_project/models/odoo_project.py
@@ -24,11 +24,10 @@ class OdooProject(models.Model):
         ],
         required=True,
     )
-    module_branch_ids = fields.Many2many(
-        comodel_name="odoo.module.branch",
-        relation="odoo_project_module_branch_rel",
-        column1="odoo_project_id", column2="module_branch_id",
-        string="Modules/Branch",
+    project_module_ids = fields.One2many(
+        comodel_name="odoo.project.module",
+        inverse_name="odoo_project_id",
+        string="Deployed Modules",
     )
     module_ids = fields.Many2many(
         comodel_name="odoo.module",
@@ -58,35 +57,39 @@ class OdooProject(models.Model):
         compute="_compute_unknown_module_ids",
     )
 
-    @api.depends("module_branch_ids.module_id")
+    @api.depends("project_module_ids.module_id")
     def _compute_module_ids(self):
         for rec in self:
-            rec.module_ids = rec.module_branch_ids.module_id.ids
+            rec.module_ids = rec.project_module_ids.module_id.ids
 
-    @api.depends("module_branch_ids")
+    @api.depends("project_module_ids")
     def _compute_modules_count(self):
         for rec in self:
-            rec.modules_count = len(rec.module_branch_ids)
+            rec.modules_count = len(rec.project_module_ids)
 
-    @api.depends("repository_id.branch_ids.module_ids", "module_branch_ids")
+    @api.depends("repository_id.branch_ids.module_ids", "project_module_ids")
     def _compute_module_not_installed_ids(self):
         for rec in self:
             all_module_ids = set(rec.repository_id.branch_ids.module_ids.ids)
-            installed_module_ids = set(rec.module_branch_ids.ids)
+            installed_module_ids = set(rec.project_module_ids.ids)
             rec.module_not_installed_ids = list(all_module_ids - installed_module_ids)
 
-    @api.depends("module_branch_ids.pr_url")
+    @api.depends("project_module_ids.pr_url")
     def _compute_unmerged_module_ids(self):
         for rec in self:
-            rec.unmerged_module_ids = rec.module_branch_ids.filtered(
-                lambda module: module.pr_url
+            rec.unmerged_module_ids = (
+                rec.project_module_ids.module_branch_id.filtered(
+                    lambda module: module.pr_url
+                )
             )
 
-    @api.depends("module_branch_ids.repository_id")
+    @api.depends("project_module_ids.repository_id")
     def _compute_unknown_module_ids(self):
         for rec in self:
-            rec.unknown_module_ids = rec.module_branch_ids.filtered(
-                lambda module: not module.repository_id
+            rec.unknown_module_ids = (
+                rec.project_module_ids.module_branch_id.filtered(
+                    lambda module: not module.repository_id
+                )
             )
 
     def open_import_modules(self):
@@ -105,12 +108,12 @@ class OdooProject(models.Model):
     def open_modules(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id(
-            "odoo_repository.odoo_module_branch_action"
+            "odoo_project.odoo_project_module_action"
         )
         ctx = action.get("context", {})
         if isinstance(ctx, str):
             ctx = ast.literal_eval(ctx)
-        action["domain"] = [("id", "in", self.module_branch_ids.ids)]
+        action["domain"] = [("id", "in", self.project_module_ids.ids)]
         ctx["search_default_group_by_org_id"] = 1
         ctx["search_default_group_by_repository_id"] = 2
         action["context"] = ctx

--- a/odoo_project/models/odoo_project_module.py
+++ b/odoo_project/models/odoo_project_module.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, fields, models
+from odoo.tools.parse_version import parse_version as v
+
+
+class OdooProjectModule(models.Model):
+    _name = "odoo.project.module"
+    _inherits = {"odoo.module.branch": "module_branch_id"}
+    _description = "Odoo Project Module"
+    _order = "name"
+
+    odoo_project_id = fields.Many2one(
+        comodel_name="odoo.project",
+        ondelete="cascade",
+        string="Project",
+    )
+    module_branch_id = fields.Many2one(
+        comodel_name="odoo.module.branch",
+        ondelete="set null",
+        string="Upstream Module",
+        required=True,
+    )
+    installed_version = fields.Char()
+    to_upgrade = fields.Boolean(
+        string="To Upgrade",
+        compute="_compute_to_upgrade",
+        store=True,
+    )
+
+    @api.depends("version", "installed_version")
+    def _compute_to_upgrade(self):
+        for rec in self:
+            rec.to_upgrade = False
+            installed_version = rec.installed_version or rec.version
+            if installed_version and rec.version:
+                rec.to_upgrade = v(installed_version) < v(rec.version)

--- a/odoo_project/security/ir.model.access.csv
+++ b/odoo_project/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_odoo_project_user,odoo_project_user,model_odoo_project,base.group_user,1,1,1,0
 access_odoo_project_manager_manager,odoo_project_manager,model_odoo_project,base.group_system,1,1,1,1
+access_odoo_project_module_user,odoo_project_module_user,model_odoo_project_module,base.group_user,1,0,0,0
 access_odoo_project_import_modules_user,odoo_project_import_modules_user,model_odoo_project_import_modules,base.group_user,1,1,1,1

--- a/odoo_project/views/menu.xml
+++ b/odoo_project/views/menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+  <menuitem id="odoo_project_main_menu"
+    parent="odoo_repository.main_odoo_repository_menu"
+    name="Projects"
+    sequence="5"/>
+
+</odoo>

--- a/odoo_project/views/odoo_module_branch.xml
+++ b/odoo_project/views/odoo_module_branch.xml
@@ -23,7 +23,7 @@
     <field name="arch" type="xml">
       <filter name="no_repository" position="after">
         <filter name="no_project" string="Installed in projects"
-          domain="[('odoo_project_ids', '=', False)]"/>
+          domain="[('odoo_project_ids', '!=', False)]"/>
         <filter name="no_project" string="No project"
           domain="[('odoo_project_ids', '=', False)]"/>
       </filter>

--- a/odoo_project/views/odoo_project.xml
+++ b/odoo_project/views/odoo_project.xml
@@ -13,7 +13,7 @@
             string="Import modules" class="btn-primary"/>
         </header>
         <sheet>
-          <field name="module_branch_ids" invisible="1"/>
+          <field name="project_module_ids" invisible="1"/>
           <div class="oe_button_box" name="button_box">
             <button name="open_modules" type="object"
               string="Modules" class="oe_stat_button" icon="fa-th-list">
@@ -27,7 +27,7 @@
             <h1><field name="name" placeholder="Project Name"/></h1>
           </div>
           <group>
-            <field name="repository_id" attrs="{'readonly': [('module_branch_ids', '!=', [])]}" />
+            <field name="repository_id" attrs="{'readonly': [('project_module_ids', '!=', [])]}" />
             <field name="odoo_version_id" readonly="1" options="{'no_open': True}" />
           </group>
           <group name="modules_unmerged" string="Modules to merge">
@@ -70,7 +70,7 @@
       <tree>
         <field name="name"/>
         <field name="odoo_version_id"/>
-        <field name="module_branch_ids"/>
+        <field name="project_module_ids"/>
       </tree>
     </field>
   </record>
@@ -83,13 +83,12 @@
       <search>
         <field name="name"/>
         <field name="odoo_version_id"/>
+        <field name="module_ids"/>
         <group expand="0" string="Group By">
           <filter name="group_by_odoo_version_id" string="Odoo Version"
             context="{'group_by': 'odoo_version_id'}"/>
           <filter name="group_by_module_ids" string="Module"
             context="{'group_by': 'module_ids'}"/>
-          <filter name="group_by_module_branch_ids" string="Module/Branch"
-            context="{'group_by': 'module_branch_ids'}"/>
         </group>
       </search>
     </field>
@@ -103,8 +102,7 @@
   </record>
 
   <menuitem id="odoo_project_menu"
-    parent="odoo_repository.main_odoo_repository_menu"
-    action="odoo_project_action"
-    sequence="5"/>
+    parent="odoo_project_main_menu"
+    action="odoo_project_action"/>
 
 </odoo>

--- a/odoo_project/views/odoo_project_module.xml
+++ b/odoo_project/views/odoo_project_module.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+  <record id="odoo_project_module_view_form" model="ir.ui.view">
+    <field name="name">odoo.project.module.form.inherit</field>
+    <field name="model">odoo.project.module</field>
+    <field name="inherit_id" ref="odoo_repository.odoo_module_branch_view_form"/>
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+      <field name="version" position="before">
+        <field name="installed_version"/>
+      </field>
+      <field name="version" position="attributes">
+        <attribute name="string">Last Version</attribute>
+      </field>
+    </field>
+  </record>
+
+  <record id="odoo_project_module_view_tree" model="ir.ui.view">
+    <field name="name">odoo.project.module.tree.inherit</field>
+    <field name="model">odoo.project.module</field>
+    <field name="inherit_id" ref="odoo_repository.odoo_module_branch_view_tree"/>
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+      <tree position="attributes">
+        <attribute name="decoration-warning">to_upgrade</attribute>
+        <attribute name="decoration-danger">pr_url</attribute>
+      </tree>
+      <field name="author_ids" position="attributes">
+        <attribute name="optional">hide</attribute>
+      </field>
+      <field name="version" position="before">
+        <field name="installed_version"/>
+        <field name="to_upgrade" invisible="1"/>
+      </field>
+      <field name="version" position="attributes">
+        <attribute name="string">Last Version</attribute>
+        <attribute name="optional"></attribute>
+      </field>
+      <field name="pr_url" position="attributes">
+        <attribute name="optional">show</attribute>
+      </field>
+    </field>
+  </record>
+
+  <record id="odoo_project_module_view_search" model="ir.ui.view">
+    <field name="name">odoo.project.module.search.inherit</field>
+    <field name="model">odoo.project.module</field>
+    <field name="inherit_id" ref="odoo_repository.odoo_module_branch_view_search"/>
+    <field name="mode">primary</field>
+    <field name="arch" type="xml">
+      <field name="license_id" position="after">
+        <field name="odoo_project_id"/>
+      </field>
+      <filter name="unmerged_pr" position="before">
+        <filter name="to_upgrade" string="To Upgrade"
+          domain="[('to_upgrade', '=', True)]"/>
+      </filter>
+    </field>
+  </record>
+
+  <record id="odoo_project_module_action" model="ir.actions.act_window">
+    <field name="name">Installed Modules</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">odoo.project.module</field>
+    <field name="view_id" ref="odoo_project_module_view_tree"/>
+  </record>
+
+  <menuitem id="odoo_project_module_menu"
+    parent="odoo_project_main_menu"
+    action="odoo_project_module_action"/>
+
+</odoo>

--- a/odoo_project_migration/models/odoo_project.py
+++ b/odoo_project_migration/models/odoo_project.py
@@ -16,7 +16,7 @@ class OdooProject(models.Model):
     )
     migrations_count = fields.Integer(compute="_compute_migrations_count")
 
-    @api.depends("module_branch_ids")
+    @api.depends("module_migration_ids")
     def _compute_migrations_count(self):
         for rec in self:
             rec.migrations_count = len(rec.module_migration_ids)

--- a/odoo_repository/views/odoo_module_branch.xml
+++ b/odoo_repository/views/odoo_module_branch.xml
@@ -99,6 +99,7 @@
         <field name="installable" optional="hide"/>
         <field name="auto_install" optional="hide"/>
         <field name="last_scanned_commit" optional="hide"/>
+        <field name="pr_url" optional="hide" widget="url"/>
         <field name="sloc_python" sum="Python"/>
         <field name="sloc_xml" sum="XML"/>
         <field name="sloc_js" sum="JS"/>


### PR DESCRIPTION
This new data model is here to distinguish available upstream modules and installed modules in a project.

It inherits from `odoo.module.branch` so it has access to all its data, but is linked to an `odoo.project` and has its own `installed_version` so it becomes easy to find modules that could be upgraded within a project.

![image](https://github.com/camptocamp/odoo-repository/assets/5315285/3e317cd5-976b-4cdc-bbf1-b6a7a7dffdd3)
